### PR TITLE
feat: add support for wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "atomic-waker"
@@ -319,6 +319,15 @@ dependencies = [
  "serde_json",
  "tokio",
  "voca_rs",
+]
+
+[[package]]
+name = "explainer-wasm"
+version = "0.1.0"
+dependencies = [
+ "explainer",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "3"
-members = ["explainer-core"]
+members = ["explainer-core", "explainer-wasm"]

--- a/README.md
+++ b/README.md
@@ -19,25 +19,29 @@ cargo add explainer
 ```
 
 ```rust
+use anyhow::Result;
 use explainer::{Explainer,Jsonify}
 
-//define a valid word
-let word = "exactly";
+#[tokio::main]
+async fn main() -> Result<()> {
+    //define a valid word
+    let word = "exactly";
 
-//this will get the instance
-let explainer = Explainer::from(word).unwrap();
+    //this will get the instance
+    let explainer = Explainer::from(word).await?;
 
-//serialize the whole instance to json
-let result = explainer.to_json().unwrap();
+    //serialize the whole instance to json
+    let result = explainer.to_json()?;
 
-//or just serialize the pronunciation field to json
-let pronunciation = explainer.pronunciation.to_json().unwrap();
+    //or just serialize the pronunciation field to json
+    let pronunciation = explainer.pronunciation.to_json()?;
 
-//or just serialize the meanings field to json
-let meanings = explainer.meanings.to_json().unwrap();
+    //or just serialize the meanings field to json
+    let meanings = explainer.meanings.to_json()?;
 
-//or just serialize the sentences field to json
-let sentences = explainer.sentences.to_json().unwrap();
+    //or just serialize the sentences field to json
+    let sentences = explainer.sentences.to_json()?;
+}
 ```
 
 > ##### Using as a CLI tool 

--- a/explainer-core/Cargo.toml
+++ b/explainer-core/Cargo.toml
@@ -18,6 +18,8 @@ reqwest = "0.12.22"
 scraper = "0.23.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
-tokio = { version = "1.47.0", features = ["full"] }
 voca_rs = "1.15.2"
 clap = { version = "4.5.43", features = ["derive"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.47.0", features = ["full"] }

--- a/explainer-core/README.md
+++ b/explainer-core/README.md
@@ -3,23 +3,27 @@ cargo add explainer
 ```
 
 ```rust
+use anyhow::Result;
 use explainer::{Explainer,Jsonify}
 
-//define a valid word
-let word = "exactly";
+#[tokio::main]
+async fn main() -> Result<()> {
+    //define a valid word
+    let word = "exactly";
 
-//this will get the instance
-let explainer = Explainer::from(word).unwrap();
+    //this will get the instance
+    let explainer = Explainer::from(word).await?;
 
-//serialize the whole instance to json
-let result = explainer.to_json().unwrap();
+    //serialize the whole instance to json
+    let result = explainer.to_json()?;
 
-//or just serialize the pronunciation field to json
-let pronunciation = explainer.pronunciation.to_json().unwrap();
+    //or just serialize the pronunciation field to json
+    let pronunciation = explainer.pronunciation.to_json()?;
 
-//or just serialize the meanings field to json
-let meanings = explainer.meanings.to_json().unwrap();
+    //or just serialize the meanings field to json
+    let meanings = explainer.meanings.to_json()?;
 
-//or just serialize the sentences field to json
-let sentences = explainer.sentences.to_json().unwrap();
+    //or just serialize the sentences field to json
+    let sentences = explainer.sentences.to_json()?;
+}
 ```

--- a/explainer-core/src/explainer.rs
+++ b/explainer-core/src/explainer.rs
@@ -94,7 +94,7 @@ impl Source {
     async fn load(word: &str) -> Result<Self> {
         let mut domain = Self::DOMAIN;
 
-        if cfg!(not(target_arch = "wasm32")) {
+        if cfg!(target_arch = "wasm32") {
             domain = "https://then.dpdns.org"
         }
 

--- a/explainer-core/src/main.rs
+++ b/explainer-core/src/main.rs
@@ -5,9 +5,10 @@ use clap::Parser;
 use cli::Cli;
 use explainer::{Explainer, Jsonify};
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let cli = Cli::parse();
-    let json_str = Explainer::from(cli.word.as_str())?.to_json()?;
+    let json_str = Explainer::from(cli.word.as_str()).await?.to_json()?;
 
     println!("{:?}", json_str);
 

--- a/explainer-core/tests/explainer_test.rs
+++ b/explainer-core/tests/explainer_test.rs
@@ -1,17 +1,17 @@
 use explainer::{Explainer, Jsonify};
 
-#[test]
-fn should_get_instance() {
+#[tokio::test]
+async fn should_get_instance() {
     let word = "extremely";
-    let result = Explainer::from(word);
+    let result = Explainer::from(word).await;
 
     assert!(result.is_ok())
 }
 
-#[test]
-fn canbe_serialized_to_json() {
+#[tokio::test]
+async fn canbe_serialized_to_json() {
     let word = "extremely";
-    let explainer = Explainer::from(word).unwrap();
+    let explainer = Explainer::from(word).await.unwrap();
 
     assert!(
         explainer.pronunciation.to_json().is_ok()
@@ -21,11 +21,11 @@ fn canbe_serialized_to_json() {
     )
 }
 
-#[test]
+#[tokio::test]
 #[should_panic]
-fn cannot_get_results() {
+async fn cannot_get_results() {
     let word = "abcijkdefguvwzyxrst";
-    let result = Explainer::from(word);
+    let result = Explainer::from(word).await;
 
     assert!(
         result.is_ok(),

--- a/explainer-wasm/Cargo.toml
+++ b/explainer-wasm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "explainer-wasm"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+explainer = { path = "../explainer-core" }
+wasm-bindgen = "0.2.100"
+wasm-bindgen-futures = "0.4.50"

--- a/explainer-wasm/src/lib.rs
+++ b/explainer-wasm/src/lib.rs
@@ -1,0 +1,11 @@
+use explainer::{Explainer, Jsonify};
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen]
+pub async fn explain(word: &str) -> String {
+    Explainer::from(word)
+        .await
+        .expect("Unable to load explainer")
+        .to_json()
+        .expect("Unable to serialize to json")
+}


### PR DESCRIPTION
feat: add support for wasm, export a function named `explain` for JS usage